### PR TITLE
Feature/snap8

### DIFF
--- a/base/config/app/install-snap.sh
+++ b/base/config/app/install-snap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/expect -f
 
 set timeout -1
-spawn sh /app/esa-snap_all_unix_7_0.sh
+spawn sh /app/esa-snap_all_unix_8_0.sh
 expect "OK \\\[o, Enter\\\], Cancel \\\[c\\\]" 
 send "\n"
 

--- a/base/config/app/update-snap.sh
+++ b/base/config/app/update-snap.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+snap --nosplash --nogui --modules --update-all 2>&1 | while read -r line; do
+    echo "$line"
+    [ "$line" = "updates=0" ] && sleep 2 && pkill -TERM -f "snap/jre/bin/java"
+done

--- a/base/dockerfile
+++ b/base/dockerfile
@@ -24,7 +24,8 @@ RUN expect -f ./install-snap.sh \
 # finished update line and then kill the process
 COPY config/app/update-snap.sh /app
 RUN chmod +x update-snap.sh \ 
-    && ./update-snap.sh
+    && ./update-snap.sh \
+    && rm updates-snap.sh
 
 # Configure snap toolbox
 COPY config/app/snap/bin/gpt.vmoptions ./snap/bin

--- a/base/dockerfile
+++ b/base/dockerfile
@@ -8,17 +8,23 @@ RUN apt-get update && apt-get -y install \
     python3-setuptools \
     wget \
     expect \
-    libgfortran3
+    libgfortran3 \
+    ttf-dejavu
 
 # Install snap toolbox
 COPY config/app/install-snap.sh /app
+RUN wget http://step.esa.int/downloads/8.0/installers/esa-snap_all_unix_8_0.sh \
+    && chmod +x install-snap.sh 
 
-RUN wget http://step.esa.int/downloads/7.0/installers/esa-snap_all_unix_7_0.sh \
-    && chmod +x install-snap.sh \
-    && ./install-snap.sh \
+RUN expect -f ./install-snap.sh \
     && rm install-snap.sh \
-    && rm esa-snap_all_unix_7_0.sh \
-    && snap --nosplash --nogui --modules --update-all
+    && rm esa-snap_all_unix_8_0.sh 
+
+# Copy update script, current snap hangs at end of toolbox update so need to scan for
+# finished update line and then kill the process
+COPY config/app/update-snap.sh /app
+RUN chmod +x update-snap.sh \ 
+    && ./update-snap.sh
 
 # Configure snap toolbox
 COPY config/app/snap/bin/gpt.vmoptions ./snap/bin

--- a/base/dockerfile
+++ b/base/dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Setup app folder
 WORKDIR /app
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get -y install \
     python3-setuptools \
     wget \
     expect \
-    libgfortran3 \
+    libgfortran5 \
     ttf-dejavu
 
 # Install snap toolbox


### PR DESCRIPTION
Updating container to run Snap 8, current version doesn't exit after module updates or lists so have disabled the check in Jenkins for now but hopefully will be fixed in the future. Have added a script to handle the toolbox updates and cope with the non exiting updates.

Updated base container to 20.04 to get fortran5 libraries needed as well as adding other required libraries