### PR TITLE
Fixing S1 container build by version pinning snap-base image

### DIFF
--- a/workflow/dockerfile
+++ b/workflow/dockerfile
@@ -1,5 +1,4 @@
-# FROM jncc/snap-base:0.0.0.2
-FROM jncc/snap-base-dev
+FROM jncc/snap-base:1.0.2
 
 # Setup app folder
 WORKDIR /app


### PR DESCRIPTION
Version pinning snap-base because it wasn't pinned before.